### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,4 +9,4 @@ sites. Simply install, begin adding messages in the admin, and then
 use the provided template tag library to retrieve them.
 
 Full documentation is included and `available online
-<http://django-soapbox.readthedocs.org/>`_.
+<https://django-soapbox.readthedocs.io/>`_.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
